### PR TITLE
Increase client compatibility - let Quassel IRC users join

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -180,6 +180,9 @@ func (daemon *Daemon) ClientRegister(client *Client, command string, cols []stri
 			return
 		}
 		nickname := cols[1]
+		if (strings.HasPrefix(nickname, ":")) {
+			nickname = strings.TrimPrefix(nickname, ":")
+		}
 		for existingClient := range daemon.clients {
 			if existingClient.nickname == nickname {
 				client.ReplyParts("433", "*", nickname, "Nickname is already in use")


### PR DESCRIPTION
Quassel prefixes the nickname in the NICK command with a colon.
This seems to be in accordance with rfc2812. Therefor check
if the first character of a nickname is a colon and remove it.