### PR TITLE
Perform Dns lookup of client addresses, omit client port in address 

### DIFF
--- a/README
+++ b/README
@@ -11,7 +11,7 @@ It does not aim to replace full featured mass scalable IRC networks:
 * It can not connect to other servers. Just standalone installation
 * It has few basic IRC commands
 * There is no support for channel operators, modes, votes, invites
-* No ident lookups, reverse DNS queries
+* No ident lookups
 
 But it has some convincing features:
 

--- a/client.go
+++ b/client.go
@@ -52,7 +52,13 @@ type Client struct {
 }
 
 func (c Client) String() string {
-	return *c.nickname + "!" + *c.username + "@" + c.conn.RemoteAddr().String()
+	addr := c.conn.RemoteAddr().String()
+	i := strings.LastIndex(addr, ":")
+	domain, err := net.LookupAddr(addr[0:i])
+	if err == nil {
+		addr = strings.TrimSuffix(domain[0], ".")
+	}
+	return *c.nickname + "!" + *c.username + "@" + addr
 }
 
 func NewClient(conn net.Conn) *Client {

--- a/client.go
+++ b/client.go
@@ -54,7 +54,8 @@ type Client struct {
 func (c Client) String() string {
 	addr := c.conn.RemoteAddr().String()
 	i := strings.LastIndex(addr, ":")
-	domain, err := net.LookupAddr(addr[0:i])
+    addr = addr[0:i]
+	domain, err := net.LookupAddr(addr)
 	if err == nil {
 		addr = strings.TrimSuffix(domain[0], ".")
 	}

--- a/client.go
+++ b/client.go
@@ -54,7 +54,7 @@ type Client struct {
 func (c Client) String() string {
 	addr := c.conn.RemoteAddr().String()
 	i := strings.LastIndex(addr, ":")
-    addr = addr[0:i]
+	addr = addr[0:i]
 	domain, err := net.LookupAddr(addr)
 	if err == nil {
 		addr = strings.TrimSuffix(domain[0], ".")


### PR DESCRIPTION
Use the domain name rather than address if a DNS lookup is successful otherwise use address without port